### PR TITLE
Fix combine groups not removing old entries when date filter active

### DIFF
--- a/Forms/Steps/TransactionCategorizationStep.cs
+++ b/Forms/Steps/TransactionCategorizationStep.cs
@@ -1418,7 +1418,8 @@ public class TransactionCategorizationStep : UserControl
         var selectedGroups = _groupsGrid.Rows
             .Cast<DataGridViewRow>()
             .Where(r => r.Selected && r.Tag is TransactionGroup)
-            .Select(r => (TransactionGroup)r.Tag!)
+            .Select(r => FullGroup((TransactionGroup)r.Tag!))
+            .Distinct()
             .ToList();
 
         if (selectedGroups.Count < 2) return;


### PR DESCRIPTION
## Summary
- When a date filter is active, `row.Tag` holds a **cloned** `TransactionGroup`, not the actual `_groups` list entry
- `_groups.Remove(g)` on a clone silently fails → old groups stayed, new combined group was added on top
- Fix: resolve each selected group through `FullGroup()` (same helper `OnSplitGroup` already uses)
- Added `.Distinct()` to guard against duplicate `_groups` entries if the same group is selected twice

## Test plan
- [ ] Select two groups and combine without any filter → verify old rows disappear, one combined row appears
- [ ] Apply a date filter, then select and combine two groups → verify old rows disappear, one combined row appears
- [ ] Combined group should retain the most common category from the merged transactions

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)